### PR TITLE
Improve background removal output handling

### DIFF
--- a/iCapture/Core/BackgroundRemover.swift
+++ b/iCapture/Core/BackgroundRemover.swift
@@ -171,7 +171,8 @@ class BackgroundRemover: ObservableObject {
                 let blend = CIFilter.blendWithMask()
                 blend.inputImage = inputCIImage
                 blend.maskImage = visionMask
-                blend.backgroundImage = CIImage.empty()
+                let transparentBackground = CIImage(color: .clear).cropped(to: inputCIImage.extent)
+                blend.backgroundImage = transparentBackground
 
                 guard let outputCI = blend.outputImage,
                       let outputCG = ciContext.createCGImage(outputCI, from: outputCI.extent) else {

--- a/iCapture/Core/CameraManager+BackgroundRemoval.swift
+++ b/iCapture/Core/CameraManager+BackgroundRemoval.swift
@@ -112,9 +112,10 @@ extension CameraManager {
             if let processedImage = UIImage(data: processedData) {
                 UIImageWriteToSavedPhotosAlbum(processedImage, nil, nil, nil)
                 print("CameraManager: Background-removed photo saved to photo library")
+            } else {
+                print("CameraManager: Unable to decode processed image data; saving original instead")
+                self.saveToPhotoLibrary(imageData: originalData)
             }
-
-            self.saveToPhotoLibrary(imageData: originalData)
         }
     }
 }

--- a/iCapture/Core/LiDARBackgroundRemover.swift
+++ b/iCapture/Core/LiDARBackgroundRemover.swift
@@ -208,7 +208,8 @@ class LiDARBackgroundRemover: ObservableObject {
         let blend = CIFilter.blendWithMask()
         blend.inputImage = input
         blend.maskImage = maskCI
-        blend.backgroundImage = CIImage.empty() // transparent
+        let transparentBackground = CIImage(color: .clear).cropped(to: input.extent)
+        blend.backgroundImage = transparentBackground // transparent
 
         guard let out = blend.outputImage,
               let outCG = ciContext.createCGImage(out, from: out.extent) else {


### PR DESCRIPTION
## Summary
- ensure background-removed renders blend against a transparent canvas for Vision- and LiDAR-based flows
- prevent overwriting successful removals by only saving the original when processing fails

## Testing
- `bash Scripts/Scripts:lint.sh` *(fails: SwiftLint not installed in container)*
- `bash Scripts/Scripts:build.sh` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db5d5d36e8833088c6020df40ac50a