### PR TITLE
Add automatic sticker export and refresh camera HUD

### DIFF
--- a/iCapture/Core/SessionManager.swift
+++ b/iCapture/Core/SessionManager.swift
@@ -191,6 +191,10 @@ class SessionManager: ObservableObject {
         let videoPath = sessionPath.appendingPathComponent("video")
         try fileManager.createDirectory(at: videoPath, withIntermediateDirectories: true)
 
+        // Create stickers subdirectory for background-removed assets
+        let stickersPath = sessionPath.appendingPathComponent("stickers")
+        try fileManager.createDirectory(at: stickersPath, withIntermediateDirectories: true)
+
         return sessionPath
     }
 
@@ -254,7 +258,10 @@ class SessionManager: ObservableObject {
         // Copy all assets
         for asset in sessionAssets {
             do {
-                try asset.copyToExportDirectory(exportURL: exportURL)
+                try asset.copyToExportDirectory(
+                    exportURL: exportURL,
+                    sessionDirectory: sessionURL
+                )
             } catch {
                 print("SessionManager: Failed to copy asset \(asset.filename): \(error)")
                 // Continue with other assets even if one fails
@@ -337,6 +344,22 @@ class SessionManager: ObservableObject {
 
     func getVideosCount() -> Int {
         return videoCount
+    }
+
+    func attachSticker(toOriginalFilename originalFilename: String, stickerFilename: String) {
+        guard let index = sessionAssets.firstIndex(where: { asset in
+            asset.filename == originalFilename && asset.type == .photo
+        }) else {
+            return
+        }
+
+        sessionAssets[index].stickerFilename = stickerFilename
+
+        do {
+            try saveSessionMetadata()
+        } catch {
+            print("SessionManager: Failed to persist sticker metadata: \(error)")
+        }
     }
 
     func getFormattedDuration() -> String {

--- a/iCapture/UI/CameraView.swift
+++ b/iCapture/UI/CameraView.swift
@@ -19,7 +19,6 @@ struct CameraView: View {
     var body: some View {
         ZStack {
             if cameraManager.isAuthorized {
-                // Camera preview
                 CameraPreviewView(previewLayer: cameraManager.previewLayer)
                     .ignoresSafeArea()
                     .onAppear {
@@ -29,395 +28,37 @@ struct CameraView: View {
                         }
                     }
 
-                // Frame box overlay
                 FrameBoxOverlay(roiDetector: cameraManager.roiDetector)
                     .ignoresSafeArea()
 
-                // Capture HUD
-                VStack {
-                    HStack {
-                        // User info and sign out
-                        VStack(alignment: .leading) {
-                            Text("Welcome, \(authManager.currentUser ?? "User")")
-                                .font(.caption)
-                                .foregroundColor(.white)
+                hudLayer
 
-                            Button(action: {
-                                authManager.signOut()
-                            }, label: {
-                                Text("Sign Out")
-                                    .font(.caption)
-                                    .foregroundColor(.yellow)
-                            })
-                        }
-                        .padding()
-                        .background(Color.black.opacity(0.7))
-                        .cornerRadius(8)
-
-                        Spacer()
-
-                        // Session status
-                        VStack(alignment: .leading, spacing: 4) {
-                            if sessionManager.isSessionActive {
-                                Text("Session Active")
-                                    .foregroundColor(.green)
-                                    .fontWeight(.semibold)
-
-                                if let session = sessionManager.currentSession {
-                                    Text("Stock: \(session.stockNumber)")
-                                        .font(.caption)
-                                        .foregroundColor(.white)
-
-                                    Text("Duration: \(sessionManager.getFormattedDuration())")
-                                        .font(.caption)
-                                        .foregroundColor(.white)
-
-                                    Text("Captures: \(sessionManager.getAssetCount())")
-                                        .font(.caption)
-                                        .foregroundColor(.white)
-
-                                    // Video recording status
-                                    if cameraManager.isVideoRecording {
-                                        Text("Video: Recording (\(cameraManager.getFormattedVideoDuration()))")
-                                            .font(.caption)
-                                            .foregroundColor(.red)
-                                            .fontWeight(.semibold)
-                                    } else {
-                                        Text("Video: Ready")
-                                            .font(.caption)
-                                            .foregroundColor(.purple)
-                                    }
-                                }
-                            } else {
-                                Text("No Session")
-                                    .foregroundColor(.orange)
-                                    .fontWeight(.semibold)
-                            }
-
-                            if cameraManager.triggerEngine.isIntervalCaptureActive {
-                                if cameraManager.roiDetector.isROIOccupied {
-                                    let occupancy = cameraManager.roiDetector.occupancyPercentage
-                                    let occupancyText = String(format: "%.1f", occupancy)
-                                    Text("ROI: Occupied (\(occupancyText)%)")
-                                        .font(.caption)
-                                        .foregroundColor(.green)
-                                } else {
-                                    Text("ROI: Clear")
-                                        .font(.caption)
-                                        .foregroundColor(.orange)
-                                }
-
-                                // Motion detection status
-                                if cameraManager.motionDetector.isVehicleStopped {
-                                    Text("Vehicle: STOPPED")
-                                        .font(.caption)
-                                        .foregroundColor(.red)
-                                        .fontWeight(.bold)
-                                } else {
-                                    let motion = cameraManager.motionDetector.motionMagnitude
-                                    let motionText = String(format: "%.3f", motion)
-                                    Text("Motion: \(motionText)")
-                                        .font(.caption)
-                                        .foregroundColor(.yellow)
-                                }
-
-                                // Photo capture info
-                                let photoInfo = cameraManager.getPhotoCaptureInfo()
-                                let resolutionText = photoInfo.is48MPSupported ? "48MP" : "12MP"
-                                Text("Photo: \(resolutionText) \(photoInfo.format)")
-                                    .font(.caption)
-                                    .foregroundColor(.cyan)
-
-                                // LiDAR status
-                                if cameraManager.useLiDARDetection {
-                                    if cameraManager.lidarDetector.isLiDARAvailable {
-                                        Text("LiDAR: Active")
-                                            .font(.caption)
-                                            .foregroundColor(.green)
-                                    } else {
-                                        Text("LiDAR: Unavailable")
-                                            .font(.caption)
-                                            .foregroundColor(.red)
-                                    }
-                                } else {
-                                    Text("Detection: Traditional")
-                                        .font(.caption)
-                                        .foregroundColor(.yellow)
-                                }
-                            }
-                        }
-                        .padding()
-                        .background(Color.black.opacity(0.7))
-                        .cornerRadius(8)
-
-                        Spacer()
-
-                        // Background removal toggle
-                        Button(action: {
-                            cameraManager.backgroundRemovalEnabled.toggle()
-                        }, label: {
-                            Image(systemName: cameraManager.backgroundRemovalEnabled ?
-                                  "photo.badge.plus" : "photo")
-                                .font(.title2)
-                                .foregroundColor(.white)
-                                .padding()
-                                .background(cameraManager.backgroundRemovalEnabled ?
-                                           Color.green : Color.gray)
-                                .clipShape(Circle())
-                        })
-
-                        Spacer()
-
-                        // LiDAR toggle button
-                        if cameraManager.useLiDARDetection {
-                            Button(action: {
-                                if cameraManager.lidarDetector.isLiDARAvailable {
-                                    cameraManager.lidarDetector.learnBackground()
-                                }
-                            }, label: {
-                                Image(systemName: "sensor.tag.radiowaves.forward.fill")
-                                    .font(.title2)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .background(cameraManager.lidarDetector.isBackgroundLearned ? Color.green : Color.purple)
-                                    .clipShape(Circle())
-                            })
-                        } else {
-                            // Traditional background sampling button
-                            Button(action: {
-                                cameraManager.roiDetector.startBackgroundSampling()
-                            }, label: {
-                                Image(systemName: cameraManager.roiDetector.isBackgroundSampling ? "waveform" : "brain.head.profile")
-                                    .font(.title2)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .background(cameraManager.roiDetector.isBackgroundSampling ? Color.orange : Color.blue)
-                                    .clipShape(Circle())
-                            })
-                            .disabled(cameraManager.roiDetector.isBackgroundSampling)
-                        }
-
-                        // Setup button
-                        Button(action: {
-                            showSetupWizard = true
-                        }, label: {
-                            Image(systemName: "gearshape.fill")
-                                .font(.title2)
-                                .foregroundColor(.white)
-                                .padding()
-                                .background(Color.blue)
-                                .clipShape(Circle())
-                        })
-
-                        // Video recording toggle button
-                        if sessionManager.isSessionActive {
-                            Button(action: {
-                                if cameraManager.isVideoRecording {
-                                    cameraManager.stopVideoRecording()
-                                } else {
-                                    cameraManager.startVideoRecording()
-                                }
-                            }, label: {
-                                Image(systemName: cameraManager.isVideoRecording ?
-                                      "stop.circle.fill" : "video.circle.fill")
-                                    .font(.title2)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .background(cameraManager.isVideoRecording ?
-                                               Color.red : Color.purple)
-                                    .clipShape(Circle())
-                            })
-                        }
-
-                        // LiDAR control buttons (only show if LiDAR is available)
-                        if cameraManager.lidarDetector.isLiDARAvailable {
-                            HStack(spacing: 8) {
-                                // LiDAR start/stop button
-                                Button(action: {
-                                    if cameraManager.lidarDetector.isSessionRunning {
-                                        cameraManager.stopLiDARDetection()
-                                    } else {
-                                        cameraManager.startLiDARDetection()
-                                    }
-                                }, label: {
-                                    Image(systemName: "sensor.tag.radiowaves.forward")
-                                        .font(.title2)
-                                        .foregroundColor(.white)
-                                        .padding()
-                                        .background(cameraManager.lidarDetector.isSessionRunning ? Color.green : Color.gray)
-                                        .clipShape(Circle())
-                                })
-
-                                // LiDAR enable/disable button
-                                Button(action: {
-                                    if cameraManager.useLiDARDetection {
-                                        cameraManager.disableLiDARDetection()
-                                    } else {
-                                        cameraManager.enableLiDARDetection()
-                                    }
-                                }, label: {
-                                    Image(systemName: "sensor.tag.radiowaves.forward.fill")
-                                        .font(.title2)
-                                        .foregroundColor(.white)
-                                        .padding()
-                                        .background(cameraManager.useLiDARDetection ? Color.purple : Color.gray)
-                                        .clipShape(Circle())
-                                })
-
-                                // Debug button
-                                Button(action: {
-                                    cameraManager.lidarDetector.debugARSessionStatus()
-                                }, label: {
-                                    Image(systemName: "ladybug")
-                                        .font(.title2)
-                                        .foregroundColor(.white)
-                                        .padding()
-                                        .background(Color.orange)
-                                        .clipShape(Circle())
-                                })
-                            }
-                        }
-
-                        // Performance overlay toggle
-                        Button(action: {
-                            showPerformanceOverlay.toggle()
-                        }, label: {
-                            Image(systemName: "chart.line.uptrend.xyaxis")
-                                .font(.title2)
-                                .foregroundColor(.white)
-                                .padding()
-                                .background(showPerformanceOverlay ? Color.orange : Color.blue)
-                                .clipShape(Circle())
-                        })
-
-                        // Session control button
-                        Button(action: {
-                            if sessionManager.isSessionActive {
-                                // End session
-                                do {
-                                    try sessionManager.endSession()
-                                    cameraManager.triggerEngine.stopSession()
-                                } catch {
-                                    print("Failed to end session: \(error)")
-                                }
-                            } else {
-                                // Start new session
-                                showStockNumberInput = true
-                            }
-                        }, label: {
-                            Image(systemName: sessionManager.isSessionActive ?
-                                  "stop.circle.fill" : "play.circle.fill")
-                                .font(.title)
-                                .foregroundColor(.white)
-                                .padding()
-                                .background(sessionManager.isSessionActive ?
-                                           Color.red : Color.green)
-                                .clipShape(Circle())
-                        })
-                    }
-                    .padding()
-
-                    // Background sampling progress
-                    if cameraManager.roiDetector.isBackgroundSampling {
-                        VStack(spacing: 8) {
-                            Text("Learning Background...")
-                                .foregroundColor(.white)
-                                .font(.headline)
-
-                            ProgressView(value: cameraManager.roiDetector.backgroundSampleProgress)
-                                .progressViewStyle(LinearProgressViewStyle(tint: .orange))
-                                .frame(width: 200)
-
-                            Text("\(Int(cameraManager.roiDetector.backgroundSampleProgress * 100))%")
-                                .foregroundColor(.white)
-                                .font(.caption)
-                        }
-                        .padding()
-                        .background(Color.black.opacity(0.8))
-                        .cornerRadius(12)
-                        .padding(.bottom, 100)
-                    }
-
-                    Spacer()
-
-                    // Manual capture button
-                    HStack {
-                        Spacer()
-
-                        Button(action: {
-                            print("CameraView: Manual capture triggered")
-                            cameraManager.capturePhoto(triggerType: .manual)
-                        }, label: {
-                            ZStack {
-                                Circle()
-                                    .fill(Color.white)
-                                    .frame(width: 80, height: 80)
-
-                                Circle()
-                                    .fill(Color.black)
-                                    .frame(width: 70, height: 70)
-
-                                Circle()
-                                    .fill(Color.white)
-                                    .frame(width: 60, height: 60)
-                            }
-                        })
-                        .disabled(!cameraManager.isSessionRunning)
-
-                        Spacer()
-                    }
-                    .padding(.bottom, 50)
-                }
-
-                // Capture flash overlay
                 if cameraManager.showCaptureFlash {
                     Color.white
                         .ignoresSafeArea()
-                        .opacity(0.8)
-                        .animation(.easeOut(duration: 0.1), value: cameraManager.showCaptureFlash)
+                        .opacity(0.75)
+                        .transition(.opacity)
                 }
 
-                // Performance overlay
                 if showPerformanceOverlay {
                     PerformanceOverlayView(performanceMonitor: cameraManager.performanceMonitor)
                         .ignoresSafeArea()
+                        .transition(.move(edge: .trailing))
                 }
             } else {
-                // Camera not authorized
-                VStack(spacing: 20) {
-                    Image(systemName: "camera.fill")
-                        .font(.system(size: 60))
-                        .foregroundColor(.gray)
-
-                    Text("Camera Access Required")
-                        .font(.title2)
-                        .fontWeight(.semibold)
-
-                    Text("iCapture needs camera access to capture vehicle photos during rotation sessions.")
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal)
-
-                    Button("Grant Camera Access") {
-                        cameraManager.checkAuthorization()
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-                .padding()
+                unauthorizedView
             }
         }
+        .animation(.easeInOut(duration: 0.2), value: cameraManager.roiDetector.isBackgroundSampling)
         .onAppear {
             print("CameraView: View appeared, starting camera session...")
             cameraManager.startSession()
-            // Connect session manager to camera manager
             cameraManager.sessionManager = sessionManager
-            // Connect session manager to video recording manager
             cameraManager.videoRecordingManager.configure(
                 sessionManager: sessionManager,
                 roiDetector: cameraManager.roiDetector
             )
 
-            // Ensure camera session is properly set up
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 print("CameraView: Checking camera session status...")
                 print("CameraView: Is authorized: \(cameraManager.isAuthorized)")
@@ -428,16 +69,13 @@ struct CameraView: View {
                     print("CameraView: Preview layer frame: \(previewLayer.frame)")
                 }
 
-                // Force preview layer frame update
                 cameraManager.updatePreviewLayerFrame()
 
-                // Check camera health and restart if needed
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                     if !cameraManager.checkCameraHealth() {
                         print("CameraView: Camera health check failed, restarting session...")
                         cameraManager.restartCameraSession()
                     } else {
-                        // Force another frame update after health check
                         cameraManager.updatePreviewLayerFrame()
                     }
                 }
@@ -447,12 +85,8 @@ struct CameraView: View {
             cameraManager.stopSession()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
-            // Update video orientation when device rotates
-            // Preview layer frame is handled by CameraPreviewView
             cameraManager.updateVideoOrientation()
         }
-
-        // Debug overlay (only show in debug builds or when enabled)
         .overlay(alignment: .topLeading) {
             if cameraManager.cameraDebugger.isDebugMode {
                 CameraDebugView(cameraDebugger: cameraManager.cameraDebugger)
@@ -474,6 +108,416 @@ struct CameraView: View {
                 cameraManager.triggerEngine.stopSession()
             }
         }
+    }
+
+    private var hudLayer: some View {
+        VStack(spacing: 0) {
+            topOverlay
+            Spacer()
+            if cameraManager.roiDetector.isBackgroundSampling {
+                backgroundSamplingBanner
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+            bottomOverlay
+        }
+        .ignoresSafeArea(edges: [.horizontal])
+    }
+
+    private var topOverlay: some View {
+        ViewThatFits {
+            topOverlayContainer {
+                HStack(alignment: .top, spacing: 16) {
+                    userCard
+                    sessionStatusView
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    quickActionControls
+                }
+            }
+
+            topOverlayContainer {
+                VStack(alignment: .leading, spacing: 16) {
+                    userCard
+                    sessionStatusView
+                    quickActionControls
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private func topOverlayContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(16)
+            .background(.ultraThinMaterial.opacity(0.85))
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private var userCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Signed in as")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            Text(authManager.currentUser ?? "User")
+                .font(.callout.weight(.semibold))
+                .foregroundColor(.white)
+            Button("Sign Out") {
+                authManager.signOut()
+            }
+            .font(.caption2.weight(.semibold))
+            .foregroundColor(.yellow)
+        }
+        .padding(12)
+        .background(Color.black.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private var quickActionControls: some View {
+        VStack(spacing: 12) {
+            iconControl(
+                systemImage: cameraManager.backgroundRemovalEnabled ? "sparkles.rectangle.stack.fill" : "sparkles.rectangle.stack",
+                title: "Auto Sticker",
+                isActive: cameraManager.backgroundRemovalEnabled,
+                tint: .green
+            ) {
+                cameraManager.backgroundRemovalEnabled.toggle()
+            }
+
+            iconControl(
+                systemImage: "chart.line.uptrend.xyaxis",
+                title: "Performance",
+                isActive: showPerformanceOverlay,
+                tint: .orange
+            ) {
+                showPerformanceOverlay.toggle()
+            }
+
+            iconControl(
+                systemImage: "gearshape.fill",
+                title: "Setup",
+                tint: .blue
+            ) {
+                showSetupWizard = true
+            }
+        }
+    }
+
+    private var sessionStatusView: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if sessionManager.isSessionActive, let session = sessionManager.currentSession {
+                Text("Session Active")
+                    .font(.headline.weight(.semibold))
+                    .foregroundColor(.green)
+
+                infoRow(icon: "number", text: "Stock \(session.stockNumber)")
+                infoRow(icon: "clock.arrow.circlepath", text: "Duration \(sessionManager.getFormattedDuration())")
+                infoRow(icon: "camera.badge.ellipsis", text: "Captures \(sessionManager.getAssetCount())")
+
+                if cameraManager.isVideoRecording {
+                    infoRow(icon: "record.circle", text: "Video \(cameraManager.getFormattedVideoDuration())", color: .red)
+                }
+            } else {
+                Text("No Active Session")
+                    .font(.headline.weight(.semibold))
+                    .foregroundColor(.orange)
+                Text("Start a session to enable auto capture and stickers.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(12)
+        .background(Color.black.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func infoRow(icon: String, text: String, color: Color = .white) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundColor(color)
+            Text(text)
+                .foregroundColor(color)
+                .font(.footnote)
+        }
+    }
+
+    private var statusRow: some View {
+        let chips = buildStatusChips()
+        return Group {
+            if chips.isEmpty {
+                EmptyView()
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(chips) { chip in
+                            statusChipView(chip)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+            }
+        }
+    }
+
+    private func statusChipView(_ chip: StatusChip) -> some View {
+        Label {
+            Text(chip.text)
+                .font(.caption)
+                .foregroundColor(.white)
+        } icon: {
+            Image(systemName: chip.icon)
+                .foregroundColor(chip.color)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.black.opacity(0.45))
+        .clipShape(Capsule())
+    }
+
+    private func buildStatusChips() -> [StatusChip] {
+        var chips: [StatusChip] = []
+
+        if sessionManager.isSessionActive {
+            chips.append(StatusChip(icon: "clock", text: sessionManager.getFormattedDuration(), color: .green))
+            chips.append(StatusChip(icon: "camera.on.rectangle", text: "Photos \(sessionManager.getPhotosCount())", color: .cyan))
+        }
+
+        if cameraManager.backgroundRemovalEnabled {
+            chips.append(StatusChip(icon: "sparkles", text: "Stickers On", color: .green))
+        }
+
+        if cameraManager.triggerEngine.isIntervalCaptureActive {
+            let occupancy = cameraManager.roiDetector.occupancyPercentage
+            let occupancyText = String(format: "ROI %.0f%%", occupancy)
+            let color: Color = cameraManager.roiDetector.isROIOccupied ? .green : .orange
+            chips.append(StatusChip(icon: "rectangle.inset.filled", text: occupancyText, color: color))
+
+            if cameraManager.motionDetector.isVehicleStopped {
+                chips.append(StatusChip(icon: "car.fill", text: "Vehicle Stopped", color: .red))
+            } else {
+                let motion = cameraManager.motionDetector.motionMagnitude
+                chips.append(StatusChip(icon: "speedometer", text: String(format: "Motion %.3f", motion), color: .yellow))
+            }
+        }
+
+        if cameraManager.useLiDARDetection {
+            let lidarColor: Color = cameraManager.lidarDetector.isSessionRunning ? .purple : .gray
+            let text = cameraManager.lidarDetector.isSessionRunning ? "LiDAR Active" : "LiDAR Ready"
+            chips.append(StatusChip(icon: "sensor.tag.radiowaves.forward", text: text, color: lidarColor))
+        } else {
+            chips.append(StatusChip(icon: "brain.head.profile", text: "Vision Detect", color: .blue))
+        }
+
+        return chips
+    }
+
+    private var bottomOverlay: some View {
+        VStack(spacing: 16) {
+            statusRow
+
+            HStack(alignment: .bottom, spacing: 20) {
+                detectionControls
+                Spacer()
+                captureButton
+                Spacer()
+                sessionControls
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 18)
+        .background(.ultraThinMaterial.opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 24)
+    }
+
+    private var detectionControls: some View {
+        HStack(spacing: 12) {
+            if cameraManager.useLiDARDetection {
+                iconControl(
+                    systemImage: "sensor.tag.radiowaves.forward",
+                    title: cameraManager.lidarDetector.isSessionRunning ? "Stop LiDAR" : "Start LiDAR",
+                    isActive: cameraManager.lidarDetector.isSessionRunning,
+                    tint: .purple
+                ) {
+                    if cameraManager.lidarDetector.isSessionRunning {
+                        cameraManager.stopLiDARDetection()
+                    } else {
+                        cameraManager.startLiDARDetection()
+                    }
+                }
+
+                iconControl(
+                    systemImage: "sensor.tag.radiowaves.forward.fill",
+                    title: cameraManager.useLiDARDetection ? "LiDAR On" : "LiDAR Off",
+                    isActive: cameraManager.useLiDARDetection,
+                    tint: .purple
+                ) {
+                    if cameraManager.useLiDARDetection {
+                        cameraManager.disableLiDARDetection()
+                    } else {
+                        cameraManager.enableLiDARDetection()
+                    }
+                }
+
+                iconControl(
+                    systemImage: "ladybug",
+                    title: "LiDAR Debug",
+                    tint: .orange
+                ) {
+                    cameraManager.lidarDetector.debugARSessionStatus()
+                }
+            } else {
+                iconControl(
+                    systemImage: cameraManager.roiDetector.isBackgroundSampling ? "waveform" : "brain.head.profile",
+                    title: cameraManager.roiDetector.isBackgroundSampling ? "Learning" : "Learn Background",
+                    isActive: cameraManager.roiDetector.isBackgroundSampling,
+                    tint: .orange,
+                    isDisabled: cameraManager.roiDetector.isBackgroundSampling
+                ) {
+                    cameraManager.roiDetector.startBackgroundSampling()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var captureButton: some View {
+        Button {
+            print("CameraView: Manual capture triggered")
+            cameraManager.capturePhoto(triggerType: .manual)
+        } label: {
+            VStack(spacing: 8) {
+                ZStack {
+                    Circle()
+                        .fill(Color.white.opacity(0.9))
+                        .frame(width: 86, height: 86)
+                    Circle()
+                        .fill(Color.black)
+                        .frame(width: 72, height: 72)
+                    Circle()
+                        .fill(cameraManager.isSessionRunning ? Color.white : Color.gray.opacity(0.6))
+                        .frame(width: 64, height: 64)
+                }
+                Text("Capture")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(cameraManager.isSessionRunning ? .white : .gray)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!cameraManager.isSessionRunning)
+    }
+
+    private var sessionControls: some View {
+        VStack(spacing: 12) {
+            iconControl(
+                systemImage: sessionManager.isSessionActive ? "stop.circle.fill" : "play.circle.fill",
+                title: sessionManager.isSessionActive ? "End Session" : "Start Session",
+                isActive: sessionManager.isSessionActive,
+                tint: sessionManager.isSessionActive ? .red : .green
+            ) {
+                if sessionManager.isSessionActive {
+                    do {
+                        try sessionManager.endSession()
+                        cameraManager.triggerEngine.stopSession()
+                    } catch {
+                        print("Failed to end session: \(error)")
+                    }
+                } else {
+                    showStockNumberInput = true
+                }
+            }
+
+            if sessionManager.isSessionActive {
+                iconControl(
+                    systemImage: cameraManager.isVideoRecording ? "stop.circle" : "video.circle",
+                    title: cameraManager.isVideoRecording ? "Stop Video" : "Record Video",
+                    isActive: cameraManager.isVideoRecording,
+                    tint: cameraManager.isVideoRecording ? .red : .purple
+                ) {
+                    if cameraManager.isVideoRecording {
+                        cameraManager.stopVideoRecording()
+                    } else {
+                        cameraManager.startVideoRecording()
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func iconControl(
+        systemImage: String,
+        title: String,
+        isActive: Bool = false,
+        tint: Color = .blue,
+        isDisabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.title3.weight(.semibold))
+                    .foregroundColor(.white)
+                Text(title)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+            .frame(width: 76, height: 76)
+            .background((isActive ? tint : Color.black.opacity(0.55)))
+            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.6 : 1.0)
+    }
+
+    private var backgroundSamplingBanner: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Learning background…")
+                .font(.headline.weight(.semibold))
+                .foregroundColor(.white)
+            ProgressView(value: cameraManager.roiDetector.backgroundSampleProgress)
+                .progressViewStyle(LinearProgressViewStyle(tint: .orange))
+            Text("\(Int(cameraManager.roiDetector.backgroundSampleProgress * 100))% complete")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: 320)
+        .background(.ultraThinMaterial.opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .padding(.bottom, 12)
+    }
+
+    private var unauthorizedView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 60))
+                .foregroundColor(.gray)
+
+            Text("Camera Access Required")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text("iCapture needs camera access to capture vehicle photos during rotation sessions.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+                .padding(.horizontal)
+
+            Button("Grant Camera Access") {
+                cameraManager.checkAuthorization()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+
+    private struct StatusChip: Identifiable {
+        let id = UUID()
+        let icon: String
+        let text: String
+        let color: Color
     }
 }
 


### PR DESCRIPTION
## Summary
- automatically crop background-removed captures into sticker PNGs and persist the files per session
- store sticker metadata on capture assets and include sticker files when creating export bundles
- reorganize the camera HUD into clearer panels with quick actions, status chips, and streamlined controls

## Testing
- `bash "Scripts/Scripts:lint.sh"` *(fails: SwiftLint not installed in container)*
- `bash "Scripts/Scripts:build.sh"` *(fails: xcodebuild unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb82092988330adb3f815e540b9a5